### PR TITLE
[FEAT] Adds interop with objects that implement get and set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ function getPath(obj: any, path: string) {
       break;
     }
 
-    current = current[segment];
+    current = typeof current.get === 'function' ? current.get(segment) : current[segment];
   }
 
   return current;
@@ -173,7 +173,11 @@ function setPath(obj: any, path: string, value: any) {
 
   let resolvedObj = objPath ? getPath(obj, objPath) : obj;
 
-  resolvedObj[key] = value;
+  if (typeof resolvedObj.set === 'function') {
+    resolvedObj.set(key, value);
+  } else {
+    resolvedObj[key] = value;
+  }
 }
 
 // **** Aliasing ****

--- a/src/tests/macros.ts
+++ b/src/tests/macros.ts
@@ -61,6 +61,66 @@ describe('Macros', () => {
       expect(foo.fooAlias).to.equal('qux');
     });
 
+    it('@alias works with Map', () => {
+      class Foo {
+        foo = new Map([['bar', 'baz']]);
+
+        @alias('foo.bar') barAlias!: string;
+      }
+
+      let foo = new Foo();
+
+      expect(foo.foo.get('bar')).to.equal('baz');
+      expect(foo.barAlias).to.equal('baz');
+
+      foo.barAlias = 'qux';
+
+      expect(foo.foo.get('bar')).to.equal('qux');
+      expect(foo.barAlias).to.equal('qux');
+
+      foo.foo.set('bar', 'quux');
+
+      expect(foo.foo.get('bar')).to.equal('quux');
+      expect(foo.barAlias).to.equal('quux');
+    });
+
+    it('@alias works with arbitrary classes that implement get and set', () => {
+      class SomeClass {
+        inner = {
+          bar: 'baz'
+        };
+
+        get(key: 'bar') {
+          return this.inner[key];
+        }
+
+        set(key: 'bar', value: string) {
+          this.inner[key] = value;
+        }
+      }
+
+      class Foo {
+        foo = new SomeClass();
+
+        @alias('foo.bar') barAlias!: string;
+      }
+
+      let foo = new Foo();
+
+      expect(foo.foo.get('bar')).to.equal('baz');
+      expect(foo.barAlias).to.equal('baz');
+
+      foo.barAlias = 'qux';
+
+      expect(foo.foo.get('bar')).to.equal('qux');
+      expect(foo.barAlias).to.equal('qux');
+
+      foo.foo.set('bar', 'quux');
+
+      expect(foo.foo.get('bar')).to.equal('quux');
+      expect(foo.barAlias).to.equal('quux');
+    });
+
     it('@deprecatingAlias', () => {
       let callCount = 0;
 


### PR DESCRIPTION
This allows the various built-in macros to work with native classes that implement `get` and `set`, such as `Map`, along with giving users a way to provide their own custom getters and setters (e.g. Ember's classic `get` and `set` syntax).