### PR TITLE
Basic support for expansion syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,23 @@ function getPath(obj: any, path: string) {
   return current;
 }
 
+function expandProperties(pattern: string): string[] {
+  const start = pattern.indexOf('{');
+  if (start < 0) {
+    return [pattern];
+  }
+  const prefix = pattern.substring(0, start);
+  const end = pattern.indexOf('}');
+  return pattern
+    .substring(start + 1, end)
+    .split(',')
+    .map(p => prefix + p);
+}
+
 function getPaths(obj: any, paths: string[]) {
-  return paths.map(p => getPath(obj, p));
+  return paths
+    .reduce((acc: string[], p: string): string[] => acc.concat(expandProperties(p)), []) // Can use flatMap instead of reduce + concat in future
+    .map(p => getPath(obj, p));
 }
 
 function setPath(obj: any, path: string, value: any) {

--- a/src/tests/macros.ts
+++ b/src/tests/macros.ts
@@ -455,6 +455,25 @@ describe('Macros', () => {
       expect(qux.fooOrBarOrBaz).to.equal(true);
     });
 
+    it('@or - nested properties with expansion syntax', () => {
+      class Foo {
+        foo = false;
+        bar = false;
+        baz = true;
+      }
+      class Qux {
+        qux = new Foo();
+
+        @or('qux.{foo,bar}') fooOrBar!: boolean;
+        @or('qux.{foo,bar,baz}') fooOrBarOrBaz!: boolean;
+      }
+
+      let qux = new Qux();
+
+      expect(qux.fooOrBar).to.equal(false);
+      expect(qux.fooOrBarOrBaz).to.equal(true);
+    });
+
     it('@lt', () => {
       class Foo {
         foo = 0;


### PR DESCRIPTION
This PR partially addresses the 2nd concern from #11.
This is how expansion syntax is implemented in Ember:
https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/metal/lib/expand_properties.ts
It doesn't support nested syntax but supports some other edge cases like:
```
'a.{b,c,d}.e' => ['a.b.e', 'a.c.e', 'a.d.e']
'{a,b,c}.d.{e,f}.g' => ['a.d.e.g', 'a.d.f.g', 'b.d.e.g', 'b.d.f.g', 'c.d.e.g', 'c.d.f.g']
```
See tests https://github.com/emberjs/ember.js/blob/master/packages/%40ember/-internals/metal/tests/expand_properties_test.js

These cases seems like it is too much for `macro-decorators` but the very basic expansion syntax can be helpful as it might be used in many Ember apps willing to migrate to `@tracked` properties.
```
'a.{b,c,d}' => ['a.b', 'a.c', 'a.d']
```