### PR TITLE
Fix array decorators breaking when array is nullish

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -760,6 +760,14 @@ function setFrom(arr: any[]) {
   return set;
 }
 
+function getArray(obj: any, path: string): any[] {
+  return getPath(obj, path) || [];
+}
+
+function getArrays(obj: any, paths: string[]): any[][] {
+  return paths.map(p => getArray(obj, p));
+}
+
 function getValues(set: Set<any>) {
   if (set.values) {
     return Array.from(set);
@@ -834,9 +842,13 @@ export function collect(...paths: string[]): PropertyDecorator {
  */
 export function diff(...paths: string[]): PropertyDecorator {
   return macro(obj => {
-    let arrays = getPaths(obj, paths);
+    if (paths.length === 0) {
+      return [];
+    }
 
-    let intersect = arrays.shift();
+    let arrays = getArrays(obj, paths);
+
+    let intersect = arrays.shift() as any[];
 
     for (let arr of arrays) {
       let values = setFrom(arr);
@@ -886,7 +898,7 @@ export function filter(
   path: string,
   fn: (value: any, index: number, arr: any[]) => boolean
 ): PropertyDecorator {
-  return macro(obj => getPath(obj, path).filter(fn));
+  return macro(obj => getArray(obj, path).filter(fn));
 }
 
 /**
@@ -984,9 +996,13 @@ export function filterBy(path: string, key: string | symbol, value?: any): Prope
  */
 export function intersect(...paths: string[]): PropertyDecorator {
   return macro(obj => {
-    let arrays = getPaths(obj, paths);
+    if (paths.length === 0) {
+      return [];
+    }
 
-    let intersect = arrays.shift();
+    let arrays = getArrays(obj, paths);
+
+    let intersect = arrays.shift() as any[];
 
     for (let arr of arrays) {
       let values = setFrom(arr);
@@ -1033,7 +1049,7 @@ export function map(
   path: string,
   fn: (value: any, i: number, arr: any[]) => any
 ): PropertyDecorator {
-  return macro(obj => getPath(obj, path).map(fn));
+  return macro(obj => getArray(obj, path).map(fn));
 }
 
 /**
@@ -1094,7 +1110,7 @@ export function mapBy(path: string, key: string | symbol): PropertyDecorator {
  * @param path The path to the array to find the max value of
  */
 export function max(path: string): PropertyDecorator {
-  return macro(obj => Math.max(...getPath(obj, path)));
+  return macro(obj => Math.max(...getArray(obj, path)));
 }
 
 /**
@@ -1120,7 +1136,7 @@ export function max(path: string): PropertyDecorator {
  * @param path The path to the array to find the min value of
  */
 export function min(path: string): PropertyDecorator {
-  return macro(obj => Math.min(...getPath(obj, path)));
+  return macro(obj => Math.min(...getArray(obj, path)));
 }
 
 /**
@@ -1159,7 +1175,7 @@ export function min(path: string): PropertyDecorator {
  */
 export function sort(path: string, fn: (a: any, b: any) => number): PropertyDecorator {
   return macro(obj =>
-    getPath(obj, path)
+    getArray(obj, path)
       .slice()
       .sort(fn)
   );
@@ -1234,7 +1250,7 @@ export function sortBy(path: string, key: string, asc = true): PropertyDecorator
  * @param path The path of the array to sum
  */
 export function sum(path: string): PropertyDecorator {
-  return macro(obj => getPath(obj, path).reduce((s: number, v: number) => s + v, 0));
+  return macro(obj => getArray(obj, path).reduce((s: number, v: number) => s + v, 0));
 }
 
 /**
@@ -1262,7 +1278,7 @@ export function sum(path: string): PropertyDecorator {
  */
 export function union(...paths: string[]): PropertyDecorator {
   return macro(obj => {
-    let arrays = getPaths(obj, paths);
+    let arrays = getArrays(obj, paths);
     let union = new Set();
 
     for (let arr of arrays) {
@@ -1326,7 +1342,7 @@ export function unique(path: string): PropertyDecorator {
  */
 export function uniqueBy(path: string, key: string): PropertyDecorator {
   return macro(obj => {
-    let arr = getPath(obj, path);
+    let arr = getArray(obj, path);
     let union = new Set();
     let values: any[] = [];
 

--- a/src/tests/macros.ts
+++ b/src/tests/macros.ts
@@ -87,7 +87,7 @@ describe('Macros', () => {
     it('@alias works with arbitrary classes that implement get and set', () => {
       class SomeClass {
         inner = {
-          bar: 'baz'
+          bar: 'baz',
         };
 
         get(key: 'bar') {
@@ -504,8 +504,9 @@ describe('Macros', () => {
         foo = [1, 2, 3];
         bar = [2];
         baz = [3];
+        empty = null;
 
-        @diff('foo', 'bar', 'baz') fooBarBaz!: number[];
+        @diff('foo', 'bar', 'baz', 'empty') fooBarBaz!: number[];
       }
 
       let foo = new Foo();
@@ -516,25 +517,31 @@ describe('Macros', () => {
     it('@filter', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @filter('foo', i => i === 1) fooFiltered!: number[];
+        @filter('empty', i => i === 1) emptyFiltered!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooFiltered).to.deep.equal([1]);
+      expect(foo.emptyFiltered).to.deep.equal([]);
     });
 
     it('@filterBy', () => {
       class Foo {
         foo = [{ num: 1 }, { num: 0 }, { num: 0 }];
+        empty = null;
 
         @filterBy('foo', 'num') fooFiltered!: number[];
+        @filterBy('empty', 'num') emptyFiltered!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooFiltered).to.deep.equal([{ num: 1 }]);
+      expect(foo.emptyFiltered).to.deep.equal([]);
     });
 
     it('@filterBy value', () => {
@@ -554,73 +561,91 @@ describe('Macros', () => {
         foo = [1, 2];
         bar = [1, 3];
         baz = [1, 4];
+        empty = null;
 
         @intersect('foo', 'bar', 'baz') fooBarBaz!: number[];
+        @intersect('foo', 'empty', 'baz') fooEmptyBaz!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooBarBaz).to.deep.equal([1]);
+      expect(foo.fooEmptyBaz).to.deep.equal([]);
     });
 
     it('@map', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @map('foo', i => i + 1) fooMapped!: number[];
+        @map('empty', i => i + 1) emptyMapped!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooMapped).to.deep.equal([2, 3, 4]);
+      expect(foo.emptyMapped).to.deep.equal([]);
     });
 
     it('@mapBy', () => {
       class Foo {
         foo = [{ num: 1 }, { num: 2 }, { num: 3 }];
+        empty = null;
 
         @mapBy('foo', 'num') fooMapped!: number[];
+        @mapBy('empty', 'num') emptyMapped!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooMapped).to.deep.equal([1, 2, 3]);
+      expect(foo.emptyMapped).to.deep.equal([]);
     });
 
     it('@max', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @max('foo') fooMax!: number[];
+        @max('empty') emptyMax!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooMax).to.equal(3);
+      expect(foo.emptyMax).to.equal(Math.max());
     });
 
     it('@min', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @min('foo') fooMin!: number[];
+        @min('empty') emptyMin!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooMin).to.equal(1);
+      expect(foo.emptyMin).to.equal(Math.min());
     });
 
     it('@sort', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @sort('foo', (a, b) => (a < b ? 1 : -1)) fooSorted!: number[];
+        @sort('empty', (a, b) => (a < b ? 1 : -1)) emptySorted!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooSorted).to.deep.equal([3, 2, 1]);
+      expect(foo.emptySorted).to.deep.equal([]);
 
       // Does not modify the original
       expect(foo.foo).to.deep.equal([1, 2, 3]);
@@ -629,25 +654,31 @@ describe('Macros', () => {
     it('@sortBy', () => {
       class Foo {
         foo = [{ num: 3 }, { num: 1 }, { num: 2 }];
+        empty = null;
 
         @sortBy('foo', 'num') fooSorted!: number[];
+        @sortBy('empty', 'num') emptySorted!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooSorted).to.deep.equal([{ num: 1 }, { num: 2 }, { num: 3 }]);
+      expect(foo.emptySorted).to.deep.equal([]);
     });
 
     it('@sum', () => {
       class Foo {
         foo = [1, 2, 3];
+        empty = null;
 
         @sum('foo') fooSum!: number[];
+        @sum('empty') emptySum!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooSum).to.equal(6);
+      expect(foo.emptySum).to.equal(0);
     });
 
     it('@union', () => {
@@ -655,8 +686,9 @@ describe('Macros', () => {
         foo = [1, 2];
         bar = [1, 3];
         baz = [2, 4];
+        empty = null;
 
-        @union('foo', 'bar', 'baz') fooBarBaz!: number[];
+        @union('foo', 'bar', 'baz', 'empty') fooBarBaz!: number[];
       }
 
       let foo = new Foo();
@@ -667,25 +699,31 @@ describe('Macros', () => {
     it('@unique', () => {
       class Foo {
         foo = [1, 2, 2, 3];
+        empty = null;
 
         @unique('foo') fooBarBaz!: number[];
+        @unique('empty') uniqueEmpty!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooBarBaz).to.deep.equal([1, 2, 3]);
+      expect(foo.uniqueEmpty).to.deep.equal([]);
     });
 
     it('@uniqueBy', () => {
       class Foo {
         foo = [{ num: 1 }, { num: 2 }, { num: 2 }, { num: 3 }];
+        empty = null;
 
         @uniqueBy('foo', 'num') fooBarBaz!: number[];
+        @uniqueBy('empty', 'num') uniqueEmpty!: number[];
       }
 
       let foo = new Foo();
 
       expect(foo.fooBarBaz).to.deep.equal([{ num: 1 }, { num: 2 }, { num: 3 }]);
+      expect(foo.uniqueEmpty).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
Fixes #21. In our application we've run several times into this issue after the transition from the `@ember/object/computed` decorators to the equivalents in this addon, because the computed decorators do ensure the return value is an array. Especially when the path represents a value that is still being resolved, this is a very common problem.